### PR TITLE
Add error message when error occurs

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const radixCLIError = "Error: Radix CLI executed with error"
+
 var rootLongHelp = strings.TrimSpace(`
 A command line interface which allows you to interact with the Radix platform through automation.
 `)
@@ -31,6 +33,7 @@ var rootCmd = &cobra.Command{
 // Execute the top level command
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(radixCLIError)
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -145,7 +145,7 @@ func getTokenFromFlagSet(cmd *cobra.Command) (*string, error) {
 	} else if tokenFromEnvironment {
 		token = os.Getenv(TokenEnvironmentName)
 		if strings.EqualFold(token, "") {
-			return nil, fmt.Errorf("Environment variable`%s` should be set", TokenEnvironmentName)
+			return nil, fmt.Errorf("Environment variable `%s` should be set", TokenEnvironmentName)
 		}
 	}
 


### PR DESCRIPTION
The change introduces a standard error at the top, which the radix-github-action can use to determine wether or not to fail the step. See https://github.com/equinor/radix-github-actions/pull/2 for more info