### PR TITLE
Create validate command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,8 +33,6 @@ var rootCmd = &cobra.Command{
 // Execute the top level command
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		// fmt.Println(radixCLIError)
-		// fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -46,12 +46,12 @@ var validateCmd = &cobra.Command{
 		}
 
 		if _, err := os.Stat(radixconfig); errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("RadixConfig file note found: %s", radixconfig)
+			return fmt.Errorf("RadixConfig file note found:\n%s", radixconfig)
 		}
 
 		ra, err := utils.GetRadixApplicationFromFile(radixconfig)
 		if err != nil {
-			return errors.Wrap(err, "RadixConfig is invalid")
+			return fmt.Errorf("RadixConfig is invalid:\n%v", err)
 		}
 
 		if printfile {

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -45,14 +45,14 @@ var validateCmd = &cobra.Command{
 		}
 
 		if _, err := os.Stat(radixconfig); errors.Is(err, os.ErrNotExist) {
-			return errors.New(fmt.Sprintf("RaixConfig file note found: %s", radixconfig))
+			return errors.New(fmt.Sprintf("RadixConfig file note found: %s", radixconfig))
 		}
 
 		ra, err := utils.GetRadixApplicationFromFile(radixconfig)
 		if err != nil {
-			fmt.Printf("Syntax error in RaixConfig file:\n\n")
+			fmt.Printf("Syntax error in RadixConfig file:\n\n")
 			fmt.Println(err)
-			return errors.New("RaixConfig is invalid")
+			return errors.New("RadixConfig is invalid")
 		}
 
 		if printfile {
@@ -62,13 +62,13 @@ var validateCmd = &cobra.Command{
 
 		err = radixvalidators.IsRadixApplicationValid(ra)
 		if err == nil {
-			fmt.Println("RaixConfig is valid")
+			fmt.Println("RadixConfig is valid")
 			return nil
 		}
 
 		fmt.Println(err)
 
-		return errors.New("RaixConfig is invalid")
+		return errors.New("RadixConfig is invalid")
 	},
 }
 

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -29,7 +29,7 @@ import (
 var validateCmd = &cobra.Command{
 	Use:   "validate",
 	Short: "Validate radixconfig.yaml",
-	Long:  `Make sure the radixconfig.yaml file has correct structure, but doe not check for logic errors in the configuration`,
+	Long:  `Check radixconfig.yaml for structural and logical errors`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		cmd.SilenceUsage = true

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -15,75 +15,21 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
+	"errors"
 
-	radixv1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
-	"github.com/equinor/radix-operator/pkg/apis/radixvalidators"
-	"github.com/equinor/radix-operator/pkg/apis/utils"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"sigs.k8s.io/yaml"
 )
 
-// logoutCmd represents the logout command
+// validateCmd represents the validate command
 var validateCmd = &cobra.Command{
 	Use:   "validate",
-	Short: "Validate radixconfig.yaml",
-	Long:  `Check radixconfig.yaml for structural and logical errors`,
+	Short: "Validate Radix resources",
+	Long:  `Validate Radix resources.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-
-		cmd.SilenceUsage = true
-
-		radixconfig, err := cmd.Flags().GetString("config-file")
-		if err != nil {
-			return err
-		}
-
-		printfile, err := cmd.Flags().GetBool("print")
-		if err != nil {
-			return err
-		}
-
-		if _, err := os.Stat(radixconfig); errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("RadixConfig file note found:\n%s", radixconfig)
-		}
-
-		ra, err := utils.GetRadixApplicationFromFile(radixconfig)
-		if err != nil {
-			return fmt.Errorf("RadixConfig is invalid:\n%v", err)
-		}
-
-		if printfile {
-			err = printRA(ra)
-			if err != nil {
-				return err
-			}
-		}
-
-		err = radixvalidators.IsRadixApplicationValid(ra)
-		if err != nil {
-			return fmt.Errorf("RadixConfig is invalid:\n%v", err)
-		}
-
-		fmt.Fprintln(os.Stderr, "RadixConfig is valid")
-		return nil
+		return errors.New("please specify the resource you want to validate")
 	},
-}
-
-func printRA(ra *radixv1.RadixApplication) error {
-	b, err := yaml.Marshal(ra)
-	if err != nil {
-		return err
-	}
-
-	fmt.Fprintf(os.Stdout, "%s", b)
-	return nil
 }
 
 func init() {
 	rootCmd.AddCommand(validateCmd)
-	validateCmd.Flags().StringP("config-file", "f", "radixconfig.yaml", "Name of the radixconfig file. Defaults to radixconfig.yaml in current directory")
-	validateCmd.Flags().BoolP("print", "p", false, "Print parsed config file")
-	setVerbosePersistentFlag(validateCmd)
 }

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -34,7 +34,7 @@ var validateCmd = &cobra.Command{
 
 		cmd.SilenceUsage = true
 
-		radixconfig, err := cmd.Flags().GetString("radixconfig")
+		radixconfig, err := cmd.Flags().GetString("config-file")
 		if err != nil {
 			return err
 		}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -1,0 +1,62 @@
+// Copyright © 2023
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/equinor/radix-operator/pkg/apis/radixvalidators"
+	"github.com/equinor/radix-operator/pkg/apis/utils"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+// logoutCmd represents the logout command
+var validateCmd = &cobra.Command{
+	Use:   "validate",
+	Short: "Validate radixconfig.yaml",
+	Long:  `Make sure the radixconfig.yaml file has correct structure, but doe not check for logic errors in the configuration`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		cmd.SilenceUsage = true
+
+		radixconfig, err := cmd.Flags().GetString("radixconfig")
+		if err != nil {
+			return err
+		}
+
+		ra, err := utils.GetRadixApplicationFromFile(radixconfig)
+		if err != nil {
+			fmt.Println(err)
+			return errors.New("Radix Config is invalid")
+		}
+
+		err = radixvalidators.IsRadixApplicationValid(ra)
+		if err == nil {
+			fmt.Println("Radixconfig is valid")
+			return nil
+		}
+
+		fmt.Println(err)
+
+		return errors.New("Radix Config is invalid")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(validateCmd)
+	validateCmd.Flags().StringP("radixconfig", "c", "radixconfig.yaml", "Path to radixconfig.yaml")
+	setVerbosePersistentFlag(validateCmd)
+}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -46,14 +46,12 @@ var validateCmd = &cobra.Command{
 		}
 
 		if _, err := os.Stat(radixconfig); errors.Is(err, os.ErrNotExist) {
-			return errors.New(fmt.Sprintf("RadixConfig file note found: %s", radixconfig))
+			return fmt.Errorf("RadixConfig file note found: %s", radixconfig)
 		}
 
 		ra, err := utils.GetRadixApplicationFromFile(radixconfig)
 		if err != nil {
-			fmt.Printf("Syntax error in RadixConfig file:\n\n")
-			fmt.Println(err)
-			return errors.New("RadixConfig is invalid")
+			return errors.Wrap(err, "RadixConfig is invalid")
 		}
 
 		if printfile {
@@ -61,25 +59,23 @@ var validateCmd = &cobra.Command{
 		}
 
 		err = radixvalidators.IsRadixApplicationValid(ra)
-		if err == nil {
-			fmt.Println("RadixConfig is valid")
-			return nil
+		if err != nil {
+			return fmt.Errorf("RadixConfig is invalid:\n%v", err)
 		}
 
-		fmt.Println(err)
-
-		return errors.New("RadixConfig is invalid")
+		fmt.Fprintln(os.Stderr, "RadixConfig is valid")
+		return nil
 	},
 }
 
 func printRA(ra *radixv1.RadixApplication) {
 	b, err := yaml.Marshal(ra)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprint(os.Stderr, err)
 		return
 	}
 
-	fmt.Printf("%s\n", b)
+	fmt.Fprintf(os.Stdout, "%s\n", b)
 }
 
 func init() {

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -74,7 +74,7 @@ var validateCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(validateCmd)
-	validateCmd.Flags().StringP("radixconfig", "c", "radixconfig.yaml", "Path to radixconfig.yaml")
+	validateCmd.Flags().StringP("config-file", "f", "radixconfig.yaml", "Name of the radixconfig file. Defaults to radixconfig.yaml in current directory")
 	validateCmd.Flags().BoolP("print", "p", false, "Print parsed config file")
 	setVerbosePersistentFlag(validateCmd)
 }

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -55,7 +55,10 @@ var validateCmd = &cobra.Command{
 		}
 
 		if printfile {
-			printRA(ra)
+			err = printRA(ra)
+			if err != nil {
+				return err
+			}
 		}
 
 		err = radixvalidators.IsRadixApplicationValid(ra)
@@ -68,14 +71,14 @@ var validateCmd = &cobra.Command{
 	},
 }
 
-func printRA(ra *radixv1.RadixApplication) {
+func printRA(ra *radixv1.RadixApplication) error {
 	b, err := yaml.Marshal(ra)
 	if err != nil {
-		fmt.Fprint(os.Stderr, err)
-		return
+		return err
 	}
 
 	fmt.Fprintf(os.Stdout, "%s\n", b)
+	return nil
 }
 
 func init() {

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -22,6 +22,7 @@ import (
 	"github.com/equinor/radix-operator/pkg/apis/utils"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
 )
 
 // logoutCmd represents the logout command
@@ -38,6 +39,11 @@ var validateCmd = &cobra.Command{
 			return err
 		}
 
+		printfile, err := cmd.Flags().GetBool("print")
+		if err != nil {
+			return err
+		}
+
 		if _, err := os.Stat(radixconfig); errors.Is(err, os.ErrNotExist) {
 			return errors.New(fmt.Sprintf("Config file note found: %s", radixconfig))
 		}
@@ -46,6 +52,10 @@ var validateCmd = &cobra.Command{
 		if err != nil {
 			fmt.Println(err)
 			return errors.New("Radix Config is invalid")
+		}
+
+		if printfile {
+			_ = yaml.NewEncoder(os.Stdout).Encode(ra.Spec)
 		}
 
 		err = radixvalidators.IsRadixApplicationValid(ra)
@@ -63,5 +73,6 @@ var validateCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(validateCmd)
 	validateCmd.Flags().StringP("radixconfig", "c", "radixconfig.yaml", "Path to radixconfig.yaml")
+	validateCmd.Flags().BoolP("print", "p", false, "Print parsed config file")
 	setVerbosePersistentFlag(validateCmd)
 }

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -22,7 +22,7 @@ import (
 	"github.com/equinor/radix-operator/pkg/apis/utils"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // logoutCmd represents the logout command
@@ -55,7 +55,8 @@ var validateCmd = &cobra.Command{
 		}
 
 		if printfile {
-			_ = yaml.NewEncoder(os.Stdout).Encode(ra.Spec)
+			_ = yaml.NewEncoder(os.Stdout).Encode(ra)
+			fmt.Println("")
 		}
 
 		err = radixvalidators.IsRadixApplicationValid(ra)

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/equinor/radix-operator/pkg/apis/radixvalidators"
 	"github.com/equinor/radix-operator/pkg/apis/utils"
@@ -35,6 +36,10 @@ var validateCmd = &cobra.Command{
 		radixconfig, err := cmd.Flags().GetString("radixconfig")
 		if err != nil {
 			return err
+		}
+
+		if _, err := os.Stat(radixconfig); errors.Is(err, os.ErrNotExist) {
+			return errors.New(fmt.Sprintf("Config file note found: %s", radixconfig))
 		}
 
 		ra, err := utils.GetRadixApplicationFromFile(radixconfig)

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -18,11 +18,12 @@ import (
 	"fmt"
 	"os"
 
+	radixv1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
 	"github.com/equinor/radix-operator/pkg/apis/radixvalidators"
 	"github.com/equinor/radix-operator/pkg/apis/utils"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"sigs.k8s.io/yaml"
 )
 
 // logoutCmd represents the logout command
@@ -56,8 +57,7 @@ var validateCmd = &cobra.Command{
 		}
 
 		if printfile {
-			_ = yaml.NewEncoder(os.Stdout).Encode(ra)
-			fmt.Println("")
+			printRA(ra)
 		}
 
 		err = radixvalidators.IsRadixApplicationValid(ra)
@@ -70,6 +70,16 @@ var validateCmd = &cobra.Command{
 
 		return errors.New("RadixConfig is invalid")
 	},
+}
+
+func printRA(ra *radixv1.RadixApplication) {
+	b, err := yaml.Marshal(ra)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Printf("%s\n", b)
 }
 
 func init() {

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -45,13 +45,14 @@ var validateCmd = &cobra.Command{
 		}
 
 		if _, err := os.Stat(radixconfig); errors.Is(err, os.ErrNotExist) {
-			return errors.New(fmt.Sprintf("Config file note found: %s", radixconfig))
+			return errors.New(fmt.Sprintf("RaixConfig file note found: %s", radixconfig))
 		}
 
 		ra, err := utils.GetRadixApplicationFromFile(radixconfig)
 		if err != nil {
+			fmt.Printf("Syntax error in RaixConfig file:\n\n")
 			fmt.Println(err)
-			return errors.New("Radix Config is invalid")
+			return errors.New("RaixConfig is invalid")
 		}
 
 		if printfile {
@@ -61,13 +62,13 @@ var validateCmd = &cobra.Command{
 
 		err = radixvalidators.IsRadixApplicationValid(ra)
 		if err == nil {
-			fmt.Println("Radixconfig is valid")
+			fmt.Println("RaixConfig is valid")
 			return nil
 		}
 
 		fmt.Println(err)
 
-		return errors.New("Radix Config is invalid")
+		return errors.New("RaixConfig is invalid")
 	},
 }
 

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -77,7 +77,7 @@ func printRA(ra *radixv1.RadixApplication) error {
 		return err
 	}
 
-	fmt.Fprintf(os.Stdout, "%s\n", b)
+	fmt.Fprintf(os.Stdout, "%s", b)
 	return nil
 }
 

--- a/cmd/validateRadixConfig.go
+++ b/cmd/validateRadixConfig.go
@@ -1,0 +1,89 @@
+// Copyright © 2023
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	radixv1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
+	"github.com/equinor/radix-operator/pkg/apis/radixvalidators"
+	"github.com/equinor/radix-operator/pkg/apis/utils"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
+)
+
+// logoutCmd represents the logout command
+var validateRadixConfigCmd = &cobra.Command{
+	Use:   "radix-config",
+	Short: "Validate radixconfig.yaml",
+	Long:  `Check radixconfig.yaml for structural and logical errors`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		cmd.SilenceUsage = true
+
+		radixconfig, err := cmd.Flags().GetString("config-file")
+		if err != nil {
+			return err
+		}
+
+		printfile, err := cmd.Flags().GetBool("print")
+		if err != nil {
+			return err
+		}
+
+		if _, err := os.Stat(radixconfig); errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("RadixConfig file note found:\n%s", radixconfig)
+		}
+
+		ra, err := utils.GetRadixApplicationFromFile(radixconfig)
+		if err != nil {
+			return fmt.Errorf("RadixConfig is invalid:\n%v", err)
+		}
+
+		if printfile {
+			err = printRA(ra)
+			if err != nil {
+				return err
+			}
+		}
+
+		err = radixvalidators.IsRadixApplicationValid(ra)
+		if err != nil {
+			return fmt.Errorf("RadixConfig is invalid:\n%v", err)
+		}
+
+		fmt.Fprintln(os.Stderr, "RadixConfig is valid")
+		return nil
+	},
+}
+
+func printRA(ra *radixv1.RadixApplication) error {
+	b, err := yaml.Marshal(ra)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stdout, "%s", b)
+	return nil
+}
+
+func init() {
+	validateCmd.AddCommand(validateRadixConfigCmd)
+	validateRadixConfigCmd.Flags().StringP("config-file", "f", "radixconfig.yaml", "Name of the radixconfig file. Defaults to radixconfig.yaml in current directory")
+	validateRadixConfigCmd.Flags().BoolP("print", "p", false, "Print parsed config file")
+	setVerbosePersistentFlag(validateRadixConfigCmd)
+}

--- a/cmd/validateRadixConfig.go
+++ b/cmd/validateRadixConfig.go
@@ -46,12 +46,12 @@ var validateRadixConfigCmd = &cobra.Command{
 		}
 
 		if _, err := os.Stat(radixconfig); errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("RadixConfig file note found:\n%s", radixconfig)
+			return fmt.Errorf("RadixConfig file not found: %s", radixconfig)
 		}
 
 		ra, err := utils.GetRadixApplicationFromFile(radixconfig)
 		if err != nil {
-			return fmt.Errorf("RadixConfig is invalid:\n%v", err)
+			return fmt.Errorf("RadixConfig is invalid: %w", err)
 		}
 
 		if printfile {
@@ -63,7 +63,7 @@ var validateRadixConfigCmd = &cobra.Command{
 
 		err = radixvalidators.IsRadixApplicationValid(ra)
 		if err != nil {
-			return fmt.Errorf("RadixConfig is invalid:\n%v", err)
+			return fmt.Errorf("RadixConfig is invalid:\n%w", err)
 		}
 
 		fmt.Fprintln(os.Stderr, "RadixConfig is valid")

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.21.0
 require (
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.1.0
 	github.com/equinor/radix-common v1.5.0
-	github.com/equinor/radix-operator v1.99.1000-0.20231102102524-b631c3a617bb
+	github.com/equinor/radix-operator v1.44.1
 	github.com/fatih/color v1.15.0
 	github.com/go-openapi/errors v0.20.4
 	github.com/go-openapi/runtime v0.26.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.21.0
 require (
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.1.0
 	github.com/equinor/radix-common v1.5.0
-	github.com/equinor/radix-operator v1.43.0
+	github.com/equinor/radix-operator v1.99.1000-0.20231102102524-b631c3a617bb
 	github.com/fatih/color v1.15.0
 	github.com/go-openapi/errors v0.20.4
 	github.com/go-openapi/runtime v0.26.0
@@ -27,6 +27,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.10.2 // indirect
+	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/analysis v0.21.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.7.0
 	k8s.io/utils v0.0.0-20230505201702-9f6742963106
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -27,7 +28,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.10.2 // indirect
-	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/analysis v0.21.4 // indirect
@@ -91,5 +91,4 @@ require (
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/secrets-store-csi-driver v1.3.3 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/equinor/radix-common v1.5.0 h1:z5hQHlKG2x16/NnV4b9ynf9n5ZageYUewE4MAN
 github.com/equinor/radix-common v1.5.0/go.mod h1:UZ69U56VFtTxABi5JjGdaqn9Df5ilfTTqzUQ0riofVM=
 github.com/equinor/radix-operator v1.43.0 h1:25vXiqy0BZrTu1VjA/kFgP7IGQ/UoFAtx0QCq0Irm8E=
 github.com/equinor/radix-operator v1.43.0/go.mod h1:fa1yXgnhluKtqlBP+k/VldbkpFRpkK5eBGfGhuilqNc=
+github.com/equinor/radix-operator v1.99.1000-0.20231102102524-b631c3a617bb h1:DYIK/6f7McCNF2tMAhsFfA/ml841NEItjzVCV7o1lug=
+github.com/equinor/radix-operator v1.99.1000-0.20231102102524-b631c3a617bb/go.mod h1:j/Lb9bcof4L+KjtHVv5GD6MqYVsxHSGsliIP6C2F8YU=
 github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
 github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/equinor/radix-common v1.5.0 h1:z5hQHlKG2x16/NnV4b9ynf9n5ZageYUewE4MAN
 github.com/equinor/radix-common v1.5.0/go.mod h1:UZ69U56VFtTxABi5JjGdaqn9Df5ilfTTqzUQ0riofVM=
 github.com/equinor/radix-operator v1.43.0 h1:25vXiqy0BZrTu1VjA/kFgP7IGQ/UoFAtx0QCq0Irm8E=
 github.com/equinor/radix-operator v1.43.0/go.mod h1:fa1yXgnhluKtqlBP+k/VldbkpFRpkK5eBGfGhuilqNc=
+github.com/equinor/radix-operator v1.44.1 h1:ogaVIERfEbeD5QexsXXZSN6k4v4hgbtFDFHoLgBkNjA=
+github.com/equinor/radix-operator v1.44.1/go.mod h1:9YBEz5p/s2YCL8FGzjvRUXgPjtrBojnjw/tAXQNzwx0=
 github.com/equinor/radix-operator v1.99.1000-0.20231102102524-b631c3a617bb h1:DYIK/6f7McCNF2tMAhsFfA/ml841NEItjzVCV7o1lug=
 github.com/equinor/radix-operator v1.99.1000-0.20231102102524-b631c3a617bb/go.mod h1:j/Lb9bcof4L+KjtHVv5GD6MqYVsxHSGsliIP6C2F8YU=
 github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=

--- a/go.sum
+++ b/go.sum
@@ -39,12 +39,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/equinor/radix-common v1.5.0 h1:z5hQHlKG2x16/NnV4b9ynf9n5ZageYUewE4MANdA96Y=
 github.com/equinor/radix-common v1.5.0/go.mod h1:UZ69U56VFtTxABi5JjGdaqn9Df5ilfTTqzUQ0riofVM=
-github.com/equinor/radix-operator v1.43.0 h1:25vXiqy0BZrTu1VjA/kFgP7IGQ/UoFAtx0QCq0Irm8E=
-github.com/equinor/radix-operator v1.43.0/go.mod h1:fa1yXgnhluKtqlBP+k/VldbkpFRpkK5eBGfGhuilqNc=
 github.com/equinor/radix-operator v1.44.1 h1:ogaVIERfEbeD5QexsXXZSN6k4v4hgbtFDFHoLgBkNjA=
 github.com/equinor/radix-operator v1.44.1/go.mod h1:9YBEz5p/s2YCL8FGzjvRUXgPjtrBojnjw/tAXQNzwx0=
-github.com/equinor/radix-operator v1.99.1000-0.20231102102524-b631c3a617bb h1:DYIK/6f7McCNF2tMAhsFfA/ml841NEItjzVCV7o1lug=
-github.com/equinor/radix-operator v1.99.1000-0.20231102102524-b631c3a617bb/go.mod h1:j/Lb9bcof4L+KjtHVv5GD6MqYVsxHSGsliIP6C2F8YU=
 github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
 github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=


### PR DESCRIPTION
# Todo:
- [x] Tag upgraded Radix Operator and run `go mod get`  to get the correct version (https://github.com/equinor/radix-operator/pull/967)


Example output:
```
go run . validate radix-config -c /home/richard/Projects/edc/rihag-edc23-radix-1/radixconfig.yaml
env prodtest refered to by component web is not defined: environment referenced by component does not exist
env devbla refered to by component redis is not defined: environment referenced by component does not exist
Error: Radix Config is invalid
exit status 1
```