### PR TITLE
Set get logs since duration

### DIFF
--- a/cmd/logsEnvironment.go
+++ b/cmd/logsEnvironment.go
@@ -20,6 +20,7 @@ import (
 	apiclient "github.com/equinor/radix-cli/generated-client/client"
 	"github.com/equinor/radix-cli/generated-client/client/environment"
 	"github.com/equinor/radix-cli/pkg/client"
+	"github.com/equinor/radix-cli/pkg/settings"
 	"github.com/spf13/cobra"
 )
 
@@ -47,6 +48,7 @@ Example:
 
 		environmentName, _ := cmd.Flags().GetString("environment")
 		previousLog, _ := cmd.Flags().GetBool("previous")
+		since, _ := cmd.Flags().GetDuration("since")
 
 		if environmentName == "" {
 			return errors.New("both `environment` and `component` are required")
@@ -64,7 +66,7 @@ Example:
 			return err
 		}
 
-		return logForComponentReplicas(cmd, apiClient, *appName, environmentName, componentReplicas, previousLog)
+		return logForComponentReplicas(cmd, apiClient, *appName, environmentName, since, componentReplicas, previousLog)
 	},
 }
 
@@ -98,5 +100,6 @@ func init() {
 	logsEnvironmentCmd.Flags().StringP("application", "a", "", "Name of the application owning the component")
 	logsEnvironmentCmd.Flags().StringP("environment", "e", "", "Environment the component runs in")
 	logsEnvironmentCmd.Flags().BoolP("previous", "p", false, "If set, print the logs for the previous instances of containers in environment component pods, if they exist")
+	logsEnvironmentCmd.Flags().DurationP("since", "s", settings.DeltaRefreshApplication, "If set, start get logs from the specified time, eg. 5m or 12h")
 	setContextSpecificPersistentFlags(logsEnvironmentCmd)
 }


### PR DESCRIPTION
```
go run . get logs component --application edc2023-radix-wi-rihag --component web --environment dev --since 24h

[web-6fdddc4f95-xtnm6] : warn: Microsoft.AspNetCore.DataProtection.Repositories.EphemeralXmlRepository[50]
[web-6fdddc4f95-xtnm6] :       Using an in-memory repository. Keys will not be persisted to storage.
[web-6fdddc4f95-xtnm6] : warn: Microsoft.AspNetCore.DataProtection.KeyManagement.XmlKeyManager[59]
[web-6fdddc4f95-xtnm6] :       Neither user profile nor HKLM registry available. Using an ephemeral key repository. Protected data will be unavailable when application exits.
[web-6fdddc4f95-xtnm6] : warn: Microsoft.AspNetCore.DataProtection.KeyManagement.XmlKeyManager[35]
[web-6fdddc4f95-xtnm6] :       No XML encryptor configured. Key {527d4d25-4fc4-49ff-b7d7-2679656017d2} may be persisted to storage in unencrypted form.
[web-6fdddc4f95-xtnm6] : info: Microsoft.Hosting.Lifetime[14]
[web-6fdddc4f95-xtnm6] :       Now listening on: http://[::]:5000
[web-6fdddc4f95-xtnm6] : info: Microsoft.Hosting.Lifetime[0]
[web-6fdddc4f95-xtnm6] :       Application started. Press Ctrl+C to shut down.
[web-6fdddc4f95-xtnm6] : info: Microsoft.Hosting.Lifetime[0]
[web-6fdddc4f95-xtnm6] :       Hosting environment: Development
[web-6fdddc4f95-xtnm6] : info: Microsoft.Hosting.Lifetime[0]
[web-6fdddc4f95-xtnm6] :       Content root path: /app^Csignal: interrupt

```