### PR TITLE
Replace device code login with interactive login

### DIFF
--- a/pkg/client/auth/client.go
+++ b/pkg/client/auth/client.go
@@ -1,17 +1,14 @@
 package auth
 
 import (
-	"fmt"
-
 	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/public"
 	radixconfig "github.com/equinor/radix-cli/pkg/config"
 )
 
 // newPublicClient creates a new authentication client
-func newPublicClient(radixConfig *radixconfig.RadixConfig, clientID, tenantID string) (*public.Client, error) {
+func newPublicClient(radixConfig *radixconfig.RadixConfig, clientID, authority string) (*public.Client, error) {
 	cacheAccessor := NewTokenCache(radixConfig)
 	cache := public.WithCache(cacheAccessor)
-	authority := fmt.Sprintf("https://login.microsoftonline.com/%s", tenantID)
 	client, err := public.New(clientID, cache, public.WithAuthority(authority))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Device code login is not supported for accounts that require compliant devices.
Change default authentication from device code to interactive, but allow use of device code by specifying --use-device-code in login command