### PR TITLE
fix: get appllication list now prints to stdout

### DIFF
--- a/cmd/getApplication.go
+++ b/cmd/getApplication.go
@@ -23,7 +23,6 @@ import (
 	"github.com/equinor/radix-cli/pkg/client"
 	"github.com/equinor/radix-cli/pkg/flagnames"
 	"github.com/equinor/radix-cli/pkg/utils/json"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -52,8 +51,9 @@ var getApplicationCmd = &cobra.Command{
 
 			if err == nil {
 				for _, application := range resp.Payload {
-					log.Infof("App: %s", application.Name)
+					fmt.Println(application.Name)
 				}
+				return nil
 			}
 			return err
 		}


### PR DESCRIPTION
When running the command `rx get application` to get a list of all applications. The list is printed out using a logging library that logs it as INFO. This makes it so that the list is not sent to stdout and can not be piped to any other command in the terminal

This pull request changes it so that it print to stdout instead.