### PR TITLE
fix: panic when using --token-environment and APP_SERVICE_ACCOUNT_TOKEN not set

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -32,7 +32,7 @@ func GetRadixApiForCommand(cmd *cobra.Command) (*radixapi.Radixapi, error) {
 	}
 	authWriter, err := getAuthWriter(cmd)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 	context, cluster, apiEnvironment := getContextClusterApiEnvironment(cmd, radixConfig)
 	endpoint := getEndpoint("server-radix-api", apiEnvironment, context, cluster)
@@ -51,7 +51,7 @@ func GetVulnerabilityScanApiForCommand(cmd *cobra.Command) (*vulnscanapi.Vulnsca
 	}
 	authWriter, err := getAuthWriter(cmd)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 	context, cluster, apiEnvironment := getContextClusterApiEnvironment(cmd, radixConfig)
 	endpoint := getEndpoint("server-radix-vulnerability-scanner-api", apiEnvironment, context, cluster)


### PR DESCRIPTION
radix-cli panics when using `--token-environment` flag and env var `APP_SERVICE_ACCOUNT_TOKEN` is not set

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x1debbc1]

goroutine 1 [running]:
github.com/equinor/radix-cli/cmd.getActiveDeploymentName(0x0, {0x7ffed48a4ee4, 0x7}, {0x7ffed48a4f08, 0x3})
	/home/runner/work/radix-cli/radix-cli/cmd/createPromotePipelineJob.go:122 +0xa1
github.com/equinor/radix-cli/cmd.init.func25(0x3c732a0, {0x2444d14?, 0x4?, 0x2444bf0?})
	/home/runner/work/radix-cli/radix-cli/cmd/createPromotePipelineJob.go:74 +0x316
github.com/spf13/cobra.(*Command).execute(0x3c732a0, {0xc0003ec240, 0x9, 0x9})
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1015 +0xa94
github.com/spf13/cobra.(*Command).ExecuteC(0x3c745e0)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1148 +0x40c
github.com/spf13/cobra.(*Command).Execute(...)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1071
github.com/equinor/radix-cli/cmd.Execute()
	/home/runner/work/radix-cli/radix-cli/cmd/root.go:34 +0x1a
main.main()
	/home/runner/work/radix-cli/radix-cli/cli/rx/main.go:26 +0x6c
Error: Process completed with exit code 2.
```

Reported by user in Slack: https://equinor.slack.com/archives/CBKM6N2JY/p1754892470345489