### PR TITLE
chore: update actions to support Node.js 24

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,27 +15,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
     - name: Log in to the Container registry
-      uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
+      uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: 'go.mod'
 
     - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v6
+      uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
       with:
         distribution: goreleaser
         version: '~> v2'

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,10 +20,10 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
     - name: Log in to the Container registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
       with:
         registry: ghcr.io
         username: ${{ github.actor }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -39,7 +39,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 2
       - uses: actions/setup-go@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
     - name: Set up Go
       uses: actions/setup-go@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,20 +14,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: 'go.mod'
 
     - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v6
+      uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
       with:
         distribution: goreleaser
         version: '~> v2'
@@ -39,13 +39,13 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: v2.5.0

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       pull-requests: read
       contents: read
-    uses: equinor/radix-reusable-workflows/.github/workflows/template-unreleased-pr-metadata.yml@v1.0.2
+    uses: equinor/radix-reusable-workflows/.github/workflows/template-unreleased-pr-metadata.yml@v1.1.0
     
   release-pull-request:
     name: Release pull request
@@ -25,7 +25,7 @@ jobs:
       pull-requests: write
       contents: read
       issues: write
-    uses: equinor/radix-reusable-workflows/.github/workflows/template-create-release-from-pr.yml@v1.0.2
+    uses: equinor/radix-reusable-workflows/.github/workflows/template-create-release-from-pr.yml@v1.1.0
     with:
       pull-request-number: ${{ matrix.pull-request-number }}
       use-github-app-token: true

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       pull-requests: read
       contents: read
-    uses: equinor/radix-reusable-workflows/.github/workflows/template-unreleased-pr-metadata.yml@v1.1.0
+    uses: equinor/radix-reusable-workflows/.github/workflows/template-unreleased-pr-metadata.yml@bbbf79dd34776ca9e9a4dc4fcf6dc643953f37e8 # v1.1.0
     
   release-pull-request:
     name: Release pull request
@@ -26,7 +26,7 @@ jobs:
       pull-requests: write
       contents: read
       issues: write
-    uses: equinor/radix-reusable-workflows/.github/workflows/template-create-release-from-pr.yml@v1.1.0
+    uses: equinor/radix-reusable-workflows/.github/workflows/template-create-release-from-pr.yml@bbbf79dd34776ca9e9a4dc4fcf6dc643953f37e8 # v1.1.0
     with:
       pull-request-number: ${{ matrix.pull-request-number }}
       use-github-app-token: true

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -5,6 +5,7 @@ on:
       - master
   workflow_dispatch:
   
+permissions: {}
 jobs:
   unreleased-prs-metadata:
     name: Get list of pending release pull requests

--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -7,6 +7,7 @@ on:
       - master
   workflow_dispatch:
 
+permissions: {}
 concurrency:
   group: ${{ github.workflow }}
 

--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   prepare-release-pr:
     name: Prepare release pull request
-    uses: equinor/radix-reusable-workflows/.github/workflows/template-prepare-release-pr.yml@v1.0.2
+    uses: equinor/radix-reusable-workflows/.github/workflows/template-prepare-release-pr.yml@bbbf79dd34776ca9e9a4dc4fcf6dc643953f37e8 # v1.1.0
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Update deprecated Node.js 20 actions to versions supporting Node.js 24:

- `actions/checkout` v4 → v6
- `equinor/radix-reusable-workflows` v1.0.2 → v1.1.0

Node.js 20 actions will be forced to run with Node.js 24 starting June 2nd, 2026.