### PR TITLE
fix: remove setting shared-secret in register application endpoint

### DIFF
--- a/cmd/createApplication.go
+++ b/cmd/createApplication.go
@@ -48,7 +48,6 @@ var createApplicationCmd = &cobra.Command{
 		}
 
 		repository, _ := cmd.Flags().GetString(flagnames.Repository)
-		sharedSecret, _ := cmd.Flags().GetString(flagnames.SharedSecret)
 		configBranch, _ := cmd.Flags().GetString(flagnames.ConfigBranch)
 		configFile, _ := cmd.Flags().GetString(flagnames.ConfigFile)
 		configurationItem, _ := cmd.Flags().GetString(flagnames.ConfigurationItem)
@@ -78,7 +77,6 @@ var createApplicationCmd = &cobra.Command{
 				RadixConfigFullName: configFile,
 				ReaderAdGroups:      readerAdGroups,
 				Repository:          &repository,
-				SharedSecret:        &sharedSecret,
 			},
 		})
 

--- a/cmd/createApplication.go
+++ b/cmd/createApplication.go
@@ -40,7 +40,7 @@ var createApplicationCmd = &cobra.Command{
 	Use:     "application",
 	Short:   "Create application",
 	Long:    "Creates a Radix application in the cluster",
-	Example: `rx create application --application your-application-name --repository https://github.com/your-repository --config-branch main --ad-groups abcdef-1234-5678-9aaa-abcdefgf --reader-ad-groups=23456789--9123-4567-8901-23456701 --shared-secret someSecretPhrase12345 --acknowledge-warnings --configuration-item "YOUR PROJECT CONFIG ITEM" --context playground`,
+	Example: `rx create application --application your-application-name --repository https://github.com/your-repository --config-branch main --ad-groups abcdef-1234-5678-9aaa-abcdefgf --reader-ad-groups=23456789--9123-4567-8901-23456701 --acknowledge-warnings --configuration-item "YOUR PROJECT CONFIG ITEM" --context playground`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		appName, err := config.GetAppNameFromConfigOrFromParameter(cmd, flagnames.Application)
 		if err != nil {
@@ -141,7 +141,6 @@ func init() {
 	createCmd.AddCommand(createApplicationCmd)
 	createApplicationCmd.Flags().StringP(flagnames.Application, "a", "", "Name of the application to create")
 	createApplicationCmd.Flags().StringP(flagnames.Repository, "", "", "The GitHub repository URL")
-	createApplicationCmd.Flags().StringP(flagnames.SharedSecret, "", "", "(Optional) Shared secret for the webhook. It is needed when use a GitHub webhook.")
 	createApplicationCmd.Flags().StringP(flagnames.ConfigBranch, "", "", "Name of the branch where Radix will read your radixconfig.yaml from")
 	createApplicationCmd.Flags().StringP(flagnames.ConfigFile, "", "", "(Optional) Name of the radix config file. Defaults to radixconfig.yaml")
 	createApplicationCmd.Flags().StringSliceP(flagnames.AdminADGroups, "", []string{}, "Admin groups (UUIDs of Microsoft Entra groups). Optional for the Playground context")

--- a/hack/setup_application.sh
+++ b/hack/setup_application.sh
@@ -24,8 +24,7 @@ PUBLIC_KEY=$(rx create application \
     --token-environment \
     --from-config \
     --repository $REPOSITORY \
-    --owner $OWNER \
-    --shared-secret $SHARED_SECRET 2>&1)
+    --owner $OWNER 2>&1)
 
 # Wait for application to be reconciled
 sleep 3

--- a/pkg/flagnames/names.go
+++ b/pkg/flagnames/names.go
@@ -41,7 +41,6 @@ const (
 	Repository             = "repository"
 	Schema                 = "schema"
 	Secret                 = "secret"
-	SharedSecret           = "shared-secret"
 	Since                  = "since"
 	SkipValidation         = "skip-validation"
 	StrictValidation       = "strict-validation"


### PR DESCRIPTION
This pull request makes a small change to the `createApplicationCmd` command by removing the use of the `SharedSecret` flag and its associated field. This simplifies the command's configuration and reduces unnecessary parameters.

- Removed the retrieval of the `SharedSecret` flag from the command flags in `cmd/createApplication.go`.
- Removed the assignment of the `SharedSecret` field in the application creation request in `cmd/createApplication.go`.