### PR TITLE
fix: Set draft when merging release PR

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: radix-runner
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -31,5 +31,6 @@ jobs:
       pull-request-number: ${{ matrix.pull-request-number }}
       use-github-app-token: true
       github-app-id: ${{ vars.GH_APP_ID }}
+      set-draft: true
     secrets:
       github-app-private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Ensure that pull requests for releases are set to draft status upon merging. This change improves the workflow for managing release pull requests.