### PR TITLE
feat: get only active deployment per environment 

### DIFF
--- a/cmd/getDeployment.go
+++ b/cmd/getDeployment.go
@@ -46,6 +46,9 @@ Examples:
 
   # Get a deployments for an application radix-test and its environment test
   rx get deployment --application radix-test --environment test
+
+  # Get only the active deployment for an application radix-test and its environment test
+  rx get deployment --application radix-test --environment test --active-only
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		appName, err := config.GetAppNameFromConfigOrFromParameter(cmd, flagnames.Application)
@@ -64,8 +67,15 @@ Examples:
 		if err != nil {
 			return err
 		}
+		activeOnly, err := cmd.Flags().GetBool(flagnames.ActiveOnly)
+		if err != nil {
+			return err
+		}
 		if deploymentName != "" && envName != "" {
 			return errors.New("options 'deployment' and 'environment' cannot be used together")
+		}
+		if activeOnly && envName == "" {
+			return errors.New("option 'active-only' requires option 'environment'")
 		}
 
 		cmd.SilenceUsage = true
@@ -80,6 +90,9 @@ Examples:
 		}
 		if deploymentName != "" {
 			return getDeployment(apiClient, appName, deploymentName)
+		}
+		if activeOnly {
+			return getActiveDeploymentForEnvironment(apiClient, appName, envName)
 		}
 		return getDeploymentForEnvironment(apiClient, appName, envName)
 	},
@@ -134,12 +147,30 @@ func getDeploymentForEnvironment(apiClient *radixapi.Radixapi, appName, envName 
 	return nil
 }
 
+func getActiveDeploymentForEnvironment(apiClient *radixapi.Radixapi, appName, envName string) error {
+	params := environment.NewGetEnvironmentParams()
+	params.WithAppName(appName)
+	params.WithEnvName(envName)
+	resp, err := apiClient.Environment.GetEnvironment(params, nil)
+	if err != nil {
+		return err
+	}
+	prettyJSON, err := json.Pretty(resp.Payload.ActiveDeployment)
+	if err != nil {
+		return err
+	}
+	fmt.Println(*prettyJSON)
+	return nil
+}
+
 func init() {
 	getCmd.AddCommand(getDeploymentCmd)
 	getDeploymentCmd.Flags().StringP(flagnames.Application, "a", "", "Name of the application")
 	getDeploymentCmd.Flags().StringP(flagnames.Deployment, "d", "", "Optional, name of a deployment. It cannot be used together with an option 'environment'.")
 	getDeploymentCmd.Flags().StringP(flagnames.Environment, "e", "", "Optional, name of the environment. It cannot be used together with an option 'deployment'.")
+	getDeploymentCmd.Flags().Bool(flagnames.ActiveOnly, false, "Optional, only return the active deployment. Requires option 'environment'.")
 	getDeploymentCmd.MarkFlagsMutuallyExclusive(flagnames.Environment, flagnames.Deployment)
+	getDeploymentCmd.MarkFlagsMutuallyExclusive(flagnames.ActiveOnly, flagnames.Deployment)
 
 	_ = getDeploymentCmd.RegisterFlagCompletionFunc(flagnames.Application, completion.ApplicationCompletion)
 	_ = getDeploymentCmd.RegisterFlagCompletionFunc(flagnames.Environment, completion.EnvironmentCompletion)

--- a/cmd/getDeployment.go
+++ b/cmd/getDeployment.go
@@ -22,6 +22,7 @@ import (
 	"github.com/equinor/radix-cli/generated/radixapi/client/application"
 	"github.com/equinor/radix-cli/generated/radixapi/client/deployment"
 	"github.com/equinor/radix-cli/generated/radixapi/client/environment"
+	"github.com/equinor/radix-cli/generated/radixapi/models"
 	"github.com/equinor/radix-cli/pkg/config"
 	"github.com/equinor/radix-cli/pkg/flagnames"
 	"github.com/equinor/radix-cli/pkg/utils/completion"
@@ -49,6 +50,9 @@ Examples:
 
   # Get only the active deployment for an application radix-test and its environment test
   rx get deployment --application radix-test --environment test --active-only
+
+  # Get only the active deployments for all environments of an application radix-test
+  rx get deployment --application radix-test --active-only
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		appName, err := config.GetAppNameFromConfigOrFromParameter(cmd, flagnames.Application)
@@ -74,9 +78,6 @@ Examples:
 		if deploymentName != "" && envName != "" {
 			return errors.New("options 'deployment' and 'environment' cannot be used together")
 		}
-		if activeOnly && envName == "" {
-			return errors.New("option 'active-only' requires option 'environment'")
-		}
 
 		cmd.SilenceUsage = true
 
@@ -86,6 +87,9 @@ Examples:
 		}
 
 		if deploymentName == "" && envName == "" {
+			if activeOnly {
+				return getActiveDeploymentForAllEnvironments(apiClient, appName)
+			}
 			return getDeploymentForAllEnvironments(apiClient, appName)
 		}
 		if deploymentName != "" {
@@ -166,12 +170,33 @@ func getActiveDeploymentForEnvironment(apiClient *radixapi.Radixapi, appName, en
 	return nil
 }
 
+func getActiveDeploymentForAllEnvironments(apiClient *radixapi.Radixapi, appName string) error {
+	params := application.NewGetApplicationParams()
+	params.WithAppName(appName)
+	resp, err := apiClient.Application.GetApplication(params, nil)
+	if err != nil {
+		return err
+	}
+	activeDeployments := make([]*models.DeploymentSummary, 0, len(resp.Payload.Environments))
+	for _, env := range resp.Payload.Environments {
+		if env.ActiveDeployment != nil {
+			activeDeployments = append(activeDeployments, env.ActiveDeployment)
+		}
+	}
+	prettyJSON, err := json.Pretty(activeDeployments)
+	if err != nil {
+		return err
+	}
+	fmt.Println(*prettyJSON)
+	return nil
+}
+
 func init() {
 	getCmd.AddCommand(getDeploymentCmd)
 	getDeploymentCmd.Flags().StringP(flagnames.Application, "a", "", "Name of the application")
 	getDeploymentCmd.Flags().StringP(flagnames.Deployment, "d", "", "Optional, name of a deployment. It cannot be used together with an option 'environment'.")
 	getDeploymentCmd.Flags().StringP(flagnames.Environment, "e", "", "Optional, name of the environment. It cannot be used together with an option 'deployment'.")
-	getDeploymentCmd.Flags().Bool(flagnames.ActiveOnly, false, "Optional, only return the active deployment. Requires option 'environment'.")
+	getDeploymentCmd.Flags().Bool(flagnames.ActiveOnly, false, "Optional, only return the active deployment(s). If 'environment' is not set, returns active deployments for all environments.")
 	getDeploymentCmd.MarkFlagsMutuallyExclusive(flagnames.Environment, flagnames.Deployment)
 	getDeploymentCmd.MarkFlagsMutuallyExclusive(flagnames.ActiveOnly, flagnames.Deployment)
 

--- a/cmd/getDeployment.go
+++ b/cmd/getDeployment.go
@@ -155,6 +155,9 @@ func getActiveDeploymentForEnvironment(apiClient *radixapi.Radixapi, appName, en
 	if err != nil {
 		return err
 	}
+	if resp.Payload.ActiveDeployment == nil {
+		    return errors.New("No active deployment found for environment")
+	}  
 	prettyJSON, err := json.Pretty(resp.Payload.ActiveDeployment)
 	if err != nil {
 		return err

--- a/cmd/getDeployment.go
+++ b/cmd/getDeployment.go
@@ -160,8 +160,8 @@ func getActiveDeploymentForEnvironment(apiClient *radixapi.Radixapi, appName, en
 		return err
 	}
 	if resp.Payload.ActiveDeployment == nil {
-		    return errors.New("No active deployment found for environment")
-	}  
+		return errors.New("no active deployment found for environment")
+	}
 	prettyJSON, err := json.Pretty(resp.Payload.ActiveDeployment)
 	if err != nil {
 		return err

--- a/generated/radixapi/client/application/regenerate_shared_secret_parameters.go
+++ b/generated/radixapi/client/application/regenerate_shared_secret_parameters.go
@@ -14,8 +14,6 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
-
-	"github.com/equinor/radix-cli/generated/radixapi/models"
 )
 
 // NewRegenerateSharedSecretParams creates a new RegenerateSharedSecretParams object,
@@ -80,12 +78,6 @@ type RegenerateSharedSecretParams struct {
 	   name of application
 	*/
 	AppName string
-
-	/* RegenerateRegenerateSharedSecretData.
-
-	   Regenerate shared secret and secret data
-	*/
-	RegenerateRegenerateSharedSecretData *models.RegenerateSharedSecretData
 
 	timeout    time.Duration
 	Context    context.Context
@@ -173,17 +165,6 @@ func (o *RegenerateSharedSecretParams) SetAppName(appName string) {
 	o.AppName = appName
 }
 
-// WithRegenerateRegenerateSharedSecretData adds the regenerateRegenerateSharedSecretData to the regenerate shared secret params
-func (o *RegenerateSharedSecretParams) WithRegenerateRegenerateSharedSecretData(regenerateRegenerateSharedSecretData *models.RegenerateSharedSecretData) *RegenerateSharedSecretParams {
-	o.SetRegenerateRegenerateSharedSecretData(regenerateRegenerateSharedSecretData)
-	return o
-}
-
-// SetRegenerateRegenerateSharedSecretData adds the regenerateRegenerateSharedSecretData to the regenerate shared secret params
-func (o *RegenerateSharedSecretParams) SetRegenerateRegenerateSharedSecretData(regenerateRegenerateSharedSecretData *models.RegenerateSharedSecretData) {
-	o.RegenerateRegenerateSharedSecretData = regenerateRegenerateSharedSecretData
-}
-
 // WriteToRequest writes these params to a swagger request
 func (o *RegenerateSharedSecretParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -211,11 +192,6 @@ func (o *RegenerateSharedSecretParams) WriteToRequest(r runtime.ClientRequest, r
 	// path param appName
 	if err := r.SetPathParam("appName", o.AppName); err != nil {
 		return err
-	}
-	if o.RegenerateRegenerateSharedSecretData != nil {
-		if err := r.SetBodyParam(o.RegenerateRegenerateSharedSecretData); err != nil {
-			return err
-		}
 	}
 
 	if len(res) > 0 {

--- a/generated/radixapi/models/application_registration.go
+++ b/generated/radixapi/models/application_registration.go
@@ -73,10 +73,6 @@ type ApplicationRegistration struct {
 	// Example: https://github.com/equinor/radix-canary-golang
 	// Required: true
 	Repository *string `json:"repository"`
-
-	// SharedSecret the shared secret of the webhook
-	// Required: true
-	SharedSecret *string `json:"sharedSecret"`
 }
 
 // Validate validates this application registration
@@ -124,10 +120,6 @@ func (m *ApplicationRegistration) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRepository(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateSharedSecret(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -230,15 +222,6 @@ func (m *ApplicationRegistration) validateReaderAdUsers(formats strfmt.Registry)
 func (m *ApplicationRegistration) validateRepository(formats strfmt.Registry) error {
 
 	if err := validate.Required("repository", "body", m.Repository); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *ApplicationRegistration) validateSharedSecret(formats strfmt.Registry) error {
-
-	if err := validate.Required("sharedSecret", "body", m.SharedSecret); err != nil {
 		return err
 	}
 

--- a/generated/radixapi/models/component.go
+++ b/generated/radixapi/models/component.go
@@ -26,6 +26,10 @@ type Component struct {
 	// Example: 4faca8595c5283a9d0f17a623b9255a0d9866a2e
 	CommitID string `json:"commitID,omitempty"`
 
+	// Cron schedules defined for a job component
+	// Example: ["0 0 * * *","*/5 * * * *"]
+	CronSchedules []string `json:"cronSchedules"`
+
 	// Array of external DNS configurations
 	ExternalDNS []*ExternalDNS `json:"externalDNS"`
 
@@ -42,6 +46,11 @@ type Component struct {
 	// Example: server
 	// Required: true
 	Name *string `json:"name"`
+
+	// NextRun is the next time the job component's cron schedule is due to run, if a cron schedule is configured.
+	// It is the earliest next run across all configured schedules, interpreted in the configured timezone and returned as a UTC timestamp.
+	// Format: date-time
+	NextRun strfmt.DateTime `json:"nextRun,omitempty"`
 
 	// Ports defines the port number and protocol that a component is exposed for internally in environment
 	Ports []*Port `json:"ports"`
@@ -119,6 +128,10 @@ func (m *Component) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateName(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateNextRun(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -210,6 +223,18 @@ func (m *Component) validateImage(formats strfmt.Registry) error {
 func (m *Component) validateName(formats strfmt.Registry) error {
 
 	if err := validate.Required("name", "body", m.Name); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Component) validateNextRun(formats strfmt.Registry) error {
+	if swag.IsZero(m.NextRun) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("nextRun", "body", "date-time", m.NextRun.String(), formats); err != nil {
 		return err
 	}
 

--- a/generated/radixapi/models/o_auth2_auxiliary_resource.go
+++ b/generated/radixapi/models/o_auth2_auxiliary_resource.go
@@ -29,10 +29,6 @@ type OAuth2AuxiliaryResource struct {
 	// Enum: ["cookie","redis","systemManaged","\"\""]
 	SessionStoreType string `json:"sessionStoreType,omitempty"`
 
-	// deployment
-	// Required: true
-	Deployment *AuxiliaryResourceDeployment `json:"deployment"`
-
 	// identity
 	Identity *Identity `json:"identity,omitempty"`
 }
@@ -46,10 +42,6 @@ func (m *OAuth2AuxiliaryResource) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateSessionStoreType(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateDeployment(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -141,30 +133,6 @@ func (m *OAuth2AuxiliaryResource) validateSessionStoreType(formats strfmt.Regist
 	return nil
 }
 
-func (m *OAuth2AuxiliaryResource) validateDeployment(formats strfmt.Registry) error {
-
-	if err := validate.Required("deployment", "body", m.Deployment); err != nil {
-		return err
-	}
-
-	if m.Deployment != nil {
-		if err := m.Deployment.Validate(formats); err != nil {
-			ve := new(errors.Validation)
-			if stderrors.As(err, &ve) {
-				return ve.ValidateName("deployment")
-			}
-			ce := new(errors.CompositeError)
-			if stderrors.As(err, &ce) {
-				return ce.ValidateName("deployment")
-			}
-
-			return err
-		}
-	}
-
-	return nil
-}
-
 func (m *OAuth2AuxiliaryResource) validateIdentity(formats strfmt.Registry) error {
 	if swag.IsZero(m.Identity) { // not required
 		return nil
@@ -193,10 +161,6 @@ func (m *OAuth2AuxiliaryResource) ContextValidate(ctx context.Context, formats s
 	var res []error
 
 	if err := m.contextValidateDeployments(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.contextValidateDeployment(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -234,27 +198,6 @@ func (m *OAuth2AuxiliaryResource) contextValidateDeployments(ctx context.Context
 			}
 		}
 
-	}
-
-	return nil
-}
-
-func (m *OAuth2AuxiliaryResource) contextValidateDeployment(ctx context.Context, formats strfmt.Registry) error {
-
-	if m.Deployment != nil {
-
-		if err := m.Deployment.ContextValidate(ctx, formats); err != nil {
-			ve := new(errors.Validation)
-			if stderrors.As(err, &ve) {
-				return ve.ValidateName("deployment")
-			}
-			ce := new(errors.CompositeError)
-			if stderrors.As(err, &ce) {
-				return ce.ValidateName("deployment")
-			}
-
-			return err
-		}
 	}
 
 	return nil

--- a/pkg/flagnames/names.go
+++ b/pkg/flagnames/names.go
@@ -2,6 +2,7 @@ package flagnames
 
 const (
 	AcknowledgeWarnings    = "acknowledge-warnings"
+	ActiveOnly             = "active-only"
 	AdminADGroups          = "ad-groups"
 	Alias                  = "alias"
 	ApiEnvironment         = "api-environment"


### PR DESCRIPTION
This pull request adds support for retrieving only the active deployment for a given application environment via a new `--active-only` flag in the `get deployment` command. 

**Active Deployment Retrieval**
- added `active-only `flag in (`flagnames/names.go`)
- added `getActiveDeploymentForEnvironment` function to retrieve and print the active deployment using the API client. (`cmd/getDeployment.go`) 



**Example command:** 

> rx get deployment --application test-app-name --environment dev --active-only

